### PR TITLE
fix lazy file upload and preview

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -457,15 +457,6 @@ export async function uploadAnexoClient(
       withCredentials: true,
     });
     console.log("Resposta da API (anexo):", response.data);
-    
-    // Se o upload foi bem-sucedido, salvar o ID do anexo como pendente
-    if (response.data?.status === 'success' && response.data?.data?.id) {
-      salvarAnexoPendente(response.data.data.id);
-      console.log("Anexo salvo como pendente para associação futura:", response.data.data.id);
-    } else {
-      console.warn("Anexo não foi salvo como pendente. Estrutura da resposta:", response.data);
-    }
-    
     return response.data;
   } catch (error: any) {
     console.error("Erro detalhado ao fazer upload:", {


### PR DESCRIPTION
## Summary
- fix upload API helper to avoid server-side localStorage usage
- add client-side pending ID storage and preview handling for file uploads

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Unexpected any)


------
https://chatgpt.com/codex/tasks/task_e_6898d35b92008322b73329ea2d6987b1