### PR TITLE
feat(prestador): improve propostas UX with modals

### DIFF
--- a/src/app/prestador/PrestadorDashboard.tsx
+++ b/src/app/prestador/PrestadorDashboard.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation";
 import { apiGetPrestadorDashboard } from "@/app/actions/prestador";
 import { apiPrestadorListOrdens } from "@/app/actions/ordens";
 import { apiPrestadorListPropostas } from "@/app/actions/propostas";
+import { ModalProposta } from "@/components/prestador/ModalProposta";
 
 import { ChevronRightIcon } from "@/components/icons/ChevronRightIcon";
 import { EmptyStateIllustration } from "@/components/icons/EmptyStateIllustration";
@@ -36,6 +37,7 @@ export default function PrestadorDashboard({ _user }: { _user: User }) {
   const [ordens, setOrdens] = useState<any[]>([]);
   const [propostas, setPropostas] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
+  const [selectedProposta, setSelectedProposta] = useState<any | null>(null);
   const router = useRouter();
 
   function formatarValor(valor: unknown, moeda: boolean = true): string {
@@ -133,10 +135,7 @@ export default function PrestadorDashboard({ _user }: { _user: User }) {
         if (ord.success) {
           setOrdens(ord.data.items || []);
         }
-        const prop = await apiPrestadorListPropostas();
-        if (prop.success) {
-          setPropostas(prop.data || []);
-        }
+        await loadPropostas();
       } catch (err) {
         console.error(err);
       }
@@ -144,6 +143,13 @@ export default function PrestadorDashboard({ _user }: { _user: User }) {
     }
     fetchData();
   }, []);
+
+  async function loadPropostas() {
+    const prop = await apiPrestadorListPropostas();
+    if (prop.success) {
+      setPropostas(prop.data || []);
+    }
+  }
 
   return (
     <div className="relative pb-20 mx-auto max-w-screen-2xl px-4 sm:px-6 lg:px-8">
@@ -335,7 +341,7 @@ export default function PrestadorDashboard({ _user }: { _user: User }) {
                         <div
                           key={p.id}
                           className="px-6 py-4 hover:bg-gray-50 group cursor-pointer min-w-[700px]"
-                          onClick={() => router.push("/prestador/propostas")}
+                          onClick={() => setSelectedProposta(p)}
                         >
                           <div className="grid grid-cols-4 gap-4 items-center">
                             <div className="font-afacad text-sm font-bold text-black">
@@ -375,6 +381,14 @@ export default function PrestadorDashboard({ _user }: { _user: User }) {
             )}
           </div>
         </div>
+      )}
+
+      {selectedProposta && (
+        <ModalProposta
+          proposta={selectedProposta}
+          onClose={() => setSelectedProposta(null)}
+          onUpdated={loadPropostas}
+        />
       )}
 
       {/* WhatsApp Float Button */}

--- a/src/app/prestador/propostas/propostas.tsx
+++ b/src/app/prestador/propostas/propostas.tsx
@@ -3,11 +3,13 @@
 import { Button } from "@/components/ui/Button";
 import { Card } from "@/components/ui/Card";
 import { useEffect, useState } from "react";
-import { apiPrestadorListPropostas, apiPrestadorAceitarProposta, apiPrestadorRecusarProposta, apiPrestadorContraproposta } from "../../actions/propostas";
+import { apiPrestadorListPropostas } from "../../actions/propostas";
+import { ModalProposta } from "@/components/prestador/ModalProposta";
 
 export default function PropostasPage() {
   const [loading, setLoading] = useState(true);
   const [items, setItems] = useState<any[]>([]);
+  const [selected, setSelected] = useState<any | null>(null);
 
   async function load() {
     setLoading(true);
@@ -20,23 +22,6 @@ export default function PropostasPage() {
     load();
   }, []);
 
-  async function aceitar(id: number) {
-    const r = await apiPrestadorAceitarProposta(id);
-    if (r.success) await load();
-  }
-  async function recusar(id: number) {
-    const motivo = prompt("Motivo da recusa?") || "";
-    const r = await apiPrestadorRecusarProposta(id, motivo);
-    if (r.success) await load();
-  }
-  async function contraproposta(id: number) {
-    const precoMin = prompt("Preço mínimo (opcional)") || undefined;
-    const precoMax = prompt("Preço máximo (opcional)") || undefined;
-    const prazo = prompt("Prazo em dias (opcional)");
-    const justificativa = prompt("Justificativa") || "";
-    const r = await apiPrestadorContraproposta(id, { precoMin, precoMax, prazo: prazo ? Number(prazo) : undefined, justificativa });
-    if (r.success) await load();
-  }
 
   return (
     <div className="relative pb-20 mx-auto max-w-screen-2xl px-4 sm:px-6 lg:px-8">
@@ -57,11 +42,7 @@ export default function PropostasPage() {
                       <div className="text-sm text-[#7F98BC]">{p.chamado?.imovel?.endereco}</div>
                       <div className="text-sm">Status: {p.status}</div>
                     </div>
-                    <div className="flex gap-2">
-                      <Button onClick={() => aceitar(p.id)} className="bg-green-600 text-white">Aceitar</Button>
-                      <Button onClick={() => recusar(p.id)} className="bg-red-600 text-white">Recusar</Button>
-                      <Button onClick={() => contraproposta(p.id)} className="bg-yellow-600 text-white">Contrapropor</Button>
-                    </div>
+                    <Button onClick={() => setSelected(p)} className="bg-blue-600 text-white">Ver detalhes</Button>
                   </div>
                 </Card>
               ))}
@@ -69,6 +50,13 @@ export default function PropostasPage() {
           )}
         </div>
       </div>
+      {selected && (
+        <ModalProposta
+          proposta={selected}
+          onClose={() => setSelected(null)}
+          onUpdated={load}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/admin/ModalAtualizarChamado.tsx
+++ b/src/components/admin/ModalAtualizarChamado.tsx
@@ -5,7 +5,6 @@ import { X } from "lucide-react";
 import { Button } from "@/components/ui/Button";
 import { Chamado } from "@/types";
 import { updateChamado } from "@/lib/api";
-import axios from "axios";
 
 interface ModalAtualizarChamadoProps {
   chamado: Chamado;

--- a/src/components/admin/ModalVisualizarChamado.tsx
+++ b/src/components/admin/ModalVisualizarChamado.tsx
@@ -5,7 +5,7 @@ import { X, User, FileText, Download, ZoomIn } from "lucide-react";
 import { Badge } from "@/components/ui/Badge";
 import { useState } from "react";
 import { useEffect } from "react";
-import { adminAssignPrestadorAction, adminListPrestadoresAction } from "@/app/actions/admin";
+import { adminListPrestadoresAction } from "@/app/actions/admin";
 
 interface ModalVisualizarChamadoProps {
   chamado: Chamado;
@@ -85,12 +85,11 @@ export function ModalVisualizarChamado({
   const [abaAtiva, setAbaAtiva] = useState("geral");
   const [imagemAmpliada, setImagemAmpliada] = useState<string | null>(null);
   const [abrirVinculo, setAbrirVinculo] = useState(false);
-  const [prestadores, setPrestadores] = useState<any[]>([]);
-  const [prestadorId, setPrestadorId] = useState<string>("");
+  const [_prestadores, _setPrestadores] = useState<any[]>([]);
 
   useEffect(() => {
     if (abrirVinculo) {
-      adminListPrestadoresAction().then((r: any) => setPrestadores(r.data || []));
+      adminListPrestadoresAction().then((r: any) => _setPrestadores(r.data || []));
     }
   }, [abrirVinculo]);
 

--- a/src/components/prestador/ModalProposta.tsx
+++ b/src/components/prestador/ModalProposta.tsx
@@ -1,0 +1,194 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/Button";
+import Input from "@/components/ui/Input";
+import {
+  apiPrestadorAceitarProposta,
+  apiPrestadorRecusarProposta,
+  apiPrestadorContraproposta,
+} from "@/app/actions/propostas";
+
+interface ModalPropostaProps {
+  proposta: any | null;
+  onClose: () => void;
+  onUpdated: () => void;
+}
+
+export function ModalProposta({ proposta, onClose, onUpdated }: ModalPropostaProps) {
+  const [step, setStep] = useState<"DETAILS" | "RECUSAR" | "CONTRA">("DETAILS");
+  const [loading, setLoading] = useState(false);
+  const [motivo, setMotivo] = useState("");
+  const [precoMin, setPrecoMin] = useState("");
+  const [precoMax, setPrecoMax] = useState("");
+  const [prazo, setPrazo] = useState("");
+  const [justificativa, setJustificativa] = useState("");
+
+  if (!proposta) return null;
+
+  function formatarValor(valor: unknown) {
+    const numero = Number(valor);
+    if (!valor || isNaN(numero)) return "R$ 0,00";
+    return new Intl.NumberFormat("pt-BR", {
+      style: "currency",
+      currency: "BRL",
+      minimumFractionDigits: 2,
+    }).format(numero);
+  }
+
+  async function handleAccept() {
+    setLoading(true);
+    const r = await apiPrestadorAceitarProposta(proposta.id);
+    setLoading(false);
+    if (r.success) {
+      onUpdated();
+      onClose();
+    }
+  }
+
+  async function handleRecusar() {
+    setLoading(true);
+    const r = await apiPrestadorRecusarProposta(proposta.id, motivo);
+    setLoading(false);
+    if (r.success) {
+      onUpdated();
+      onClose();
+    }
+  }
+
+  async function handleContraproposta() {
+    setLoading(true);
+    const r = await apiPrestadorContraproposta(proposta.id, {
+      precoMin: precoMin || undefined,
+      precoMax: precoMax || undefined,
+      prazo: prazo ? Number(prazo) : undefined,
+      justificativa,
+    });
+    setLoading(false);
+    if (r.success) {
+      onUpdated();
+      onClose();
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 bg-black/30 flex items-center justify-center p-4">
+      <div className="bg-white rounded-2xl p-6 w-full max-w-lg">
+        {step === "DETAILS" && (
+          <>
+            <h2 className="text-2xl font-bold mb-4 text-center">Detalhes da proposta</h2>
+            <div className="space-y-2 mb-6 text-sm">
+              <div>
+                <span className="font-bold">Chamado:</span> {proposta.chamado?.numeroChamado}
+              </div>
+              <div>
+                <span className="font-bold">Condomínio:</span> {proposta.chamado?.imovel?.nome || proposta.chamado?.imovel?.endereco}
+              </div>
+              {(proposta.precoSugeridoMin || proposta.precoSugeridoMax) && (
+                <div>
+                  <span className="font-bold">Proposta:</span> {formatarValor(proposta.precoSugeridoMin)} ~ {formatarValor(proposta.precoSugeridoMax)}
+                </div>
+              )}
+              {proposta.prazoSugerido && (
+                <div>
+                  <span className="font-bold">Prazo:</span> {proposta.prazoSugerido} dias
+                </div>
+              )}
+            </div>
+            {loading ? (
+              <div className="flex justify-center">
+                <img src="/loading.gif" alt="Carregando..." className="w-12 h-12" />
+              </div>
+            ) : (
+              <div className="flex flex-col sm:flex-row gap-2">
+                <Button className="flex-1 bg-red-600 text-white" onClick={() => setStep("RECUSAR")}>
+                  Recusar
+                </Button>
+                <Button className="flex-1 bg-yellow-500 text-white" onClick={() => setStep("CONTRA")}>
+                  Fazer contraproposta
+                </Button>
+                <Button className="flex-1 bg-green-600 text-white" onClick={handleAccept}>
+                  Aceitar proposta
+                </Button>
+              </div>
+            )}
+          </>
+        )}
+
+        {step === "RECUSAR" && (
+          <>
+            <h2 className="text-2xl font-bold mb-4 text-center">Recusar proposta</h2>
+            <div className="mb-4">
+              <textarea
+                className="w-full border border-gray-300 rounded-md p-2"
+                placeholder="Motivo da recusa"
+                value={motivo}
+                onChange={(e) => setMotivo(e.target.value)}
+              />
+            </div>
+            {loading ? (
+              <div className="flex justify-center">
+                <img src="/loading.gif" alt="Carregando..." className="w-12 h-12" />
+              </div>
+            ) : (
+              <div className="flex flex-col sm:flex-row gap-2">
+                <Button className="flex-1 bg-gray-200 text-black" onClick={() => setStep("DETAILS")}>Voltar</Button>
+                <Button className="flex-1 bg-red-600 text-white" onClick={handleRecusar}>
+                  Enviar recusa
+                </Button>
+              </div>
+            )}
+          </>
+        )}
+
+        {step === "CONTRA" && (
+          <>
+            <h2 className="text-2xl font-bold mb-4 text-center">Fazer contraproposta</h2>
+            <div className="space-y-3 mb-4">
+              <Input
+                label="Preço mínimo"
+                placeholder="R$ 0,00"
+                value={precoMin}
+                onChange={(e) => setPrecoMin(e.target.value)}
+              />
+              <Input
+                label="Preço máximo"
+                placeholder="R$ 0,00"
+                value={precoMax}
+                onChange={(e) => setPrecoMax(e.target.value)}
+              />
+              <Input
+                label="Prazo (dias)"
+                type="number"
+                placeholder="0"
+                value={prazo}
+                onChange={(e) => setPrazo(e.target.value)}
+              />
+              <div>
+                <label className="block text-sm font-medium text-gray-700">Justificativa</label>
+                <textarea
+                  className="w-full border border-gray-300 rounded-md p-2 mt-1"
+                  value={justificativa}
+                  onChange={(e) => setJustificativa(e.target.value)}
+                />
+              </div>
+            </div>
+            {loading ? (
+              <div className="flex justify-center">
+                <img src="/loading.gif" alt="Carregando..." className="w-12 h-12" />
+              </div>
+            ) : (
+              <div className="flex flex-col sm:flex-row gap-2">
+                <Button className="flex-1 bg-gray-200 text-black" onClick={() => setStep("DETAILS")}>Voltar</Button>
+                <Button className="flex-1 bg-blue-600 text-white" onClick={handleContraproposta}>
+                  Enviar contraproposta
+                </Button>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/sindico/ModalNovoChamado.tsx
+++ b/src/components/sindico/ModalNovoChamado.tsx
@@ -2,7 +2,7 @@ import { createChamadoAction } from "@/app/actions/chamados";
 import { getImoveisAction } from "@/app/actions/imoveis";
 import { debugAnexosPendentes, getAnexosPendentes, limparAnexosPendentes, updateAnexoChamadoIdClient } from "@/lib/api";
 import { Anexo, Imovel, NovoChamadoData } from "@/types";
-import { Building, MapPin, Plus, X } from "lucide-react";
+import { MapPin, Plus, X } from "lucide-react";
 import { useEffect, useState } from "react";
 import { CondySelect } from "../forms/CondySelect";
 import { FileUpload } from "../forms/FileUpload";


### PR DESCRIPTION
## Summary
- add ModalProposta component to handle viewing and responding to service proposals
- integrate proposal modal into prestador dashboard and proposals page
- clean up unused imports for lint

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68acefaf36988322894832ff5fac9a33