### PR TITLE
feat: improve prestador proposals UI

### DIFF
--- a/src/app/actions/ordens.ts
+++ b/src/app/actions/ordens.ts
@@ -15,7 +15,10 @@ export async function apiPrestadorListOrdens(page: number = 1, limit: number = 1
       headers: { Authorization: `Bearer ${session.token}` },
       params: { page, limit },
     });
-    return { success: true, data: res.data };
+    const raw = res.data;
+    // Backend retorna { items, meta } direto
+    const data = raw?.data ? raw.data : raw;
+    return { success: true, data };
   } catch (e: any) {
     return { success: false, error: e.response?.data?.message || e.message };
   }

--- a/src/app/prestador/propostas/PropostaModals.tsx
+++ b/src/app/prestador/propostas/PropostaModals.tsx
@@ -1,0 +1,222 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/Button";
+import Input from "@/components/ui/Input";
+import {
+  apiPrestadorAceitarProposta,
+  apiPrestadorRecusarProposta,
+  apiPrestadorContraproposta,
+} from "../../actions/propostas";
+
+function formatarValor(valor: any) {
+  const numero = Number(valor);
+  if (isNaN(numero)) return "-";
+  return numero.toLocaleString("pt-BR", {
+    style: "currency",
+    currency: "BRL",
+    minimumFractionDigits: 2,
+  });
+}
+
+export function ModalDetalhesProposta({ proposta, onClose, onSuccess }: any) {
+  const [recusarOpen, setRecusarOpen] = useState(false);
+  const [contraOpen, setContraOpen] = useState(false);
+
+  async function aceitar() {
+    const r = await apiPrestadorAceitarProposta(proposta.id);
+    if (r.success) {
+      onClose();
+      onSuccess();
+    }
+  }
+
+  return (
+    <>
+      <div className="fixed inset-0 z-50 bg-black/30 flex items-center justify-center p-4">
+        <div className="bg-white rounded-2xl p-6 w-full max-w-xl shadow-xl">
+          <h2 className="text-2xl font-bold mb-6">Detalhes da proposta</h2>
+
+          <div className="space-y-4 mb-6">
+            <div>
+              <h3 className="font-semibold mb-1">Informações do cliente</h3>
+              <p className="text-sm text-gray-600">
+                {proposta.chamado?.solicitante?.name || "-"}
+              </p>
+              <p className="text-sm text-gray-600">
+                {proposta.chamado?.imovel?.endereco || "-"}
+              </p>
+            </div>
+            <div>
+              <h3 className="font-semibold mb-1">Informações da proposta</h3>
+              <p className="text-sm text-gray-600">
+                Chamado {proposta.chamado?.numeroChamado || "-"}
+              </p>
+              <p className="text-sm text-gray-600">
+                Valor: {formatarValor(proposta.precoMin)} a {formatarValor(proposta.precoMax)}
+              </p>
+            </div>
+          </div>
+
+          <div className="flex flex-col-reverse sm:flex-row gap-2 justify-end">
+            <Button
+              variant="destructive"
+              onClick={() => setRecusarOpen(true)}
+              className="sm:min-w-[150px]"
+            >
+              Recusar proposta
+            </Button>
+            <Button
+              variant="secondary"
+              onClick={() => setContraOpen(true)}
+              className="sm:min-w-[150px]"
+            >
+              Fazer contraproposta
+            </Button>
+            <Button
+              onClick={aceitar}
+              className="bg-green-600 hover:bg-green-700 text-white sm:min-w-[150px]"
+            >
+              Aceitar proposta
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      {recusarOpen && (
+        <ModalRecusarProposta
+          propostaId={proposta.id}
+          onClose={() => setRecusarOpen(false)}
+          onSuccess={() => {
+            setRecusarOpen(false);
+            onClose();
+            onSuccess();
+          }}
+        />
+      )}
+      {contraOpen && (
+        <ModalContraproposta
+          propostaId={proposta.id}
+          onClose={() => setContraOpen(false)}
+          onSuccess={() => {
+            setContraOpen(false);
+            onClose();
+            onSuccess();
+          }}
+        />
+      )}
+    </>
+  );
+}
+
+export function ModalRecusarProposta({ propostaId, onClose, onSuccess }: any) {
+  const [motivo, setMotivo] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  async function enviar() {
+    setLoading(true);
+    const r = await apiPrestadorRecusarProposta(propostaId, motivo);
+    setLoading(false);
+    if (r.success) {
+      onSuccess();
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 bg-black/40 flex items-center justify-center p-4">
+      <div className="bg-white rounded-2xl p-6 w-full max-w-md shadow-xl">
+        <h2 className="text-xl font-bold mb-4">Motivo da recusa</h2>
+        <textarea
+          className="w-full border rounded-md p-2 mb-4 min-h-[100px]"
+          placeholder="Descreva o motivo"
+          value={motivo}
+          onChange={(e) => setMotivo(e.target.value)}
+        />
+        <div className="flex flex-col-reverse sm:flex-row gap-2 justify-end">
+          <Button variant="secondary" onClick={onClose} className="sm:min-w-[120px]">
+            Cancelar
+          </Button>
+          <Button
+            onClick={enviar}
+            disabled={loading}
+            className="bg-red-600 hover:bg-red-700 text-white sm:min-w-[150px]"
+          >
+            {loading ? "Enviando..." : "Recusar"}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function ModalContraproposta({ propostaId, onClose, onSuccess }: any) {
+  const [precoMin, setPrecoMin] = useState("");
+  const [precoMax, setPrecoMax] = useState("");
+  const [prazo, setPrazo] = useState("");
+  const [justificativa, setJustificativa] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  async function enviar() {
+    setLoading(true);
+    const r = await apiPrestadorContraproposta(propostaId, {
+      precoMin: precoMin || undefined,
+      precoMax: precoMax || undefined,
+      prazo: prazo ? Number(prazo) : undefined,
+      justificativa,
+    });
+    setLoading(false);
+    if (r.success) {
+      onSuccess();
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 bg-black/40 flex items-center justify-center p-4">
+      <div className="bg-white rounded-2xl p-6 w-full max-w-md shadow-xl">
+        <h2 className="text-2xl font-bold mb-6">Fazer contraproposta</h2>
+        <div className="space-y-4">
+          <Input
+            label="Valor mínimo"
+            value={precoMin}
+            onChange={(e) => setPrecoMin(e.target.value)}
+            placeholder="R$"
+          />
+          <Input
+            label="Valor máximo"
+            value={precoMax}
+            onChange={(e) => setPrecoMax(e.target.value)}
+            placeholder="R$"
+          />
+          <Input
+            label="Prazo em dias"
+            value={prazo}
+            onChange={(e) => setPrazo(e.target.value)}
+            type="number"
+            placeholder="Ex: 5"
+          />
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Justificativa</label>
+            <textarea
+              className="w-full border rounded-md p-2 min-h-[80px]"
+              value={justificativa}
+              onChange={(e) => setJustificativa(e.target.value)}
+            />
+          </div>
+        </div>
+        <div className="flex flex-col-reverse sm:flex-row gap-2 justify-end mt-6">
+          <Button variant="secondary" onClick={onClose} className="sm:min-w-[120px]">
+            Voltar
+          </Button>
+          <Button
+            onClick={enviar}
+            disabled={loading}
+            className="bg-indigo-600 hover:bg-indigo-700 text-white sm:min-w-[150px]"
+          >
+            {loading ? "Enviando..." : "Enviar"}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/src/app/prestador/propostas/propostas.tsx
+++ b/src/app/prestador/propostas/propostas.tsx
@@ -1,13 +1,24 @@
 "use client";
 
 import { Button } from "@/components/ui/Button";
-import { Card } from "@/components/ui/Card";
 import { useEffect, useState } from "react";
-import { apiPrestadorListPropostas, apiPrestadorAceitarProposta, apiPrestadorRecusarProposta, apiPrestadorContraproposta } from "../../actions/propostas";
+import { apiPrestadorListPropostas } from "../../actions/propostas";
+import { ModalDetalhesProposta } from "./PropostaModals";
+
+function formatarValor(valor: any) {
+  const numero = Number(valor);
+  if (isNaN(numero)) return "-";
+  return numero.toLocaleString("pt-BR", {
+    style: "currency",
+    currency: "BRL",
+    minimumFractionDigits: 2,
+  });
+}
 
 export default function PropostasPage() {
   const [loading, setLoading] = useState(true);
   const [items, setItems] = useState<any[]>([]);
+  const [selected, setSelected] = useState<any | null>(null);
 
   async function load() {
     setLoading(true);
@@ -20,57 +31,52 @@ export default function PropostasPage() {
     load();
   }, []);
 
-  async function aceitar(id: number) {
-    const r = await apiPrestadorAceitarProposta(id);
-    if (r.success) await load();
-  }
-  async function recusar(id: number) {
-    const motivo = prompt("Motivo da recusa?") || "";
-    const r = await apiPrestadorRecusarProposta(id, motivo);
-    if (r.success) await load();
-  }
-  async function contraproposta(id: number) {
-    const precoMin = prompt("Preço mínimo (opcional)") || undefined;
-    const precoMax = prompt("Preço máximo (opcional)") || undefined;
-    const prazo = prompt("Prazo em dias (opcional)");
-    const justificativa = prompt("Justificativa") || "";
-    const r = await apiPrestadorContraproposta(id, { precoMin, precoMax, prazo: prazo ? Number(prazo) : undefined, justificativa });
-    if (r.success) await load();
-  }
-
   return (
     <div className="relative pb-20 mx-auto max-w-screen-2xl px-4 sm:px-6 lg:px-8">
       <div className="container relative z-10">
-        <div className="font-afacad text-2xl font-bold mb-4">Propostas de Serviço</div>
-        <div className="bg-white rounded-2xl shadow-sm w-full p-4">
+        <div className="font-afacad text-2xl font-bold mb-4">Propostas de serviços Condy</div>
+        <div className="bg-white rounded-2xl shadow-sm w-full p-4 overflow-x-auto">
           {loading ? (
             <div className="flex items-center justify-center min-h-[180px]"><img src="/loading.gif" alt="Carregando..." className="w-12 h-12" /></div>
           ) : items.length === 0 ? (
             <div className="text-center text-[#7F98BC]">Nenhuma proposta.</div>
           ) : (
-            <div className="space-y-3">
-              {items.map((p) => (
-                <Card key={p.id} className="p-4">
-                  <div className="flex items-center justify-between">
-                    <div>
-                      <div className="font-bold">Chamado {p.chamado?.numeroChamado}</div>
-                      <div className="text-sm text-[#7F98BC]">{p.chamado?.imovel?.endereco}</div>
-                      <div className="text-sm">Status: {p.status}</div>
-                    </div>
-                    <div className="flex gap-2">
-                      <Button onClick={() => aceitar(p.id)} className="bg-green-600 text-white">Aceitar</Button>
-                      <Button onClick={() => recusar(p.id)} className="bg-red-600 text-white">Recusar</Button>
-                      <Button onClick={() => contraproposta(p.id)} className="bg-yellow-600 text-white">Contrapropor</Button>
-                    </div>
-                  </div>
-                </Card>
-              ))}
-            </div>
+            <table className="min-w-full text-sm">
+              <thead>
+                <tr className="text-left text-gray-500">
+                  <th className="px-3 py-2">Chamado</th>
+                  <th className="px-3 py-2">Cliente</th>
+                  <th className="px-3 py-2">Endereço</th>
+                  <th className="px-3 py-2">Valor</th>
+                  <th className="px-3 py-2"></th>
+                </tr>
+              </thead>
+              <tbody className="divide-y">
+                {items.map((p) => (
+                  <tr key={p.id} className="hover:bg-gray-50">
+                    <td className="px-3 py-2 font-medium">{p.chamado?.numeroChamado}</td>
+                    <td className="px-3 py-2">{p.chamado?.solicitante?.name || "-"}</td>
+                    <td className="px-3 py-2">{p.chamado?.imovel?.endereco || "-"}</td>
+                    <td className="px-3 py-2">{formatarValor(p.precoMin)} a {formatarValor(p.precoMax)}</td>
+                    <td className="px-3 py-2">
+                      <Button size="sm" onClick={() => setSelected(p)}>Ver detalhes</Button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
           )}
         </div>
       </div>
+
+      {selected && (
+        <ModalDetalhesProposta
+          proposta={selected}
+          onClose={() => setSelected(null)}
+          onSuccess={load}
+        />
+      )}
     </div>
   );
 }
-
 


### PR DESCRIPTION
## Summary
- redesign provider proposals list and add detail view modal
- enable in-modal actions to accept, reject with justification, or send counterproposal

## Testing
- `yarn lint` *(fails: 'axios' is defined but never used)*

------
https://chatgpt.com/codex/tasks/task_e_68acefaf36988322894832ff5fac9a33